### PR TITLE
grunt-gh-pages の導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-node_modules
-dist
+.grunt
 .tmp
 .sass-cache
 .idea
+
+dist
+
+node_modules
 bower_components

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -318,6 +318,13 @@ module.exports = function (grunt) {
         dest: '.tmp/scripts',
         ext: '.js'
       }
+    },
+
+    'gh-pages': {
+      options: {
+        base: 'dist'
+      },
+      src: '**/*'
     }
   });
 
@@ -350,7 +357,8 @@ module.exports = function (grunt) {
     'copy:dist',
     'rev',
     'usemin',
-    'htmlmin'
+    'htmlmin',
+    'gh-pages'
   ]);
 
   grunt.registerTask('default', [

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-gh-pages": "^0.10.0",
     "grunt-mocha": "^0.4.10",
     "grunt-modernizr": "^0.5.2",
     "grunt-newer": "^0.7.0",


### PR DESCRIPTION
grunt build で gh-pages ブランチにビルド成果物をコミットし、origin への push まで一気にやります。
