### PR TITLE
#38 build時に画像ファイルへのリンクが壊れてしまう問題の解消

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -190,10 +190,16 @@ module.exports = function (grunt) {
           '<%= config.dist %>',
           '<%= config.dist %>/images',
           '<%= config.dist %>/styles'
-        ]
+        ],
+        patterns: {
+          js: [
+            [/(images\/.*?\.(?:gif|jpeg|jpg|png|webp))/gm, 'Update the JS to reference our revved images']
+          ]
+        }
       },
       html: ['<%= config.dist %>/{,*/}*.html'],
-      css: ['<%= config.dist %>/styles/{,*/}*.css']
+      css: ['<%= config.dist %>/styles/{,*/}*.css'],
+      js: '<%= config.dist %>/scripts/*.js'
     },
 
     // The following *-min tasks produce minified files in the dist folder

--- a/app/scripts/views/fes-detail-modal.tag
+++ b/app/scripts/views/fes-detail-modal.tag
@@ -26,7 +26,7 @@
                 <dt>目玉</dt>
                 <dd>2千人規模で踊る親子三代千葉おどり</dd>
               </dl>
-              <img src="../../images/chiba-odori.jpg" alt=""/>
+              <img src="/images/chiba-odori.jpg" alt=""/>
             </div>
             <table class="table table-bordered">
               <thred>

--- a/app/scripts/views/fes-list.tag
+++ b/app/scripts/views/fes-list.tag
@@ -71,8 +71,8 @@
 
       // Put the Pointer Icon
       var centerPointerIcon = L.icon({
-        iconUrl: '../../images/icon_pointer.png',
-        iconRetinaUrl: '../../images/icon_pointer.png',
+        iconUrl: '/images/icon_pointer.png',
+        iconRetinaUrl: '/images/icon_pointer.png',
         iconSize: [35, 35],
         iconAnchor: [17, 17],
         popupAnchor: [0, 0]


### PR DESCRIPTION
ブラウザキャッシュ対応としてbuildに画像ファイル名称が変更され、cssやhtmlに記載されているパスも全て自動で置換されるようになっているのですが、javascriptファイルはその置換対象に含まれていませんでした。

javascriptファイルも置換対象に含めることで問題の解消をしています。
