### PR TITLE
Google Search Console用にsitemap.xmlを追加

### DIFF
--- a/app/sitemap.xml
+++ b/app/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+ <url>
+   <loc>http://festival.code4chiba.org/index.html</loc>
+ </url>
+</urlset>


### PR DESCRIPTION
Google Search Consoleでサイト上のsitemap.xmlを指定してクロール対象を教える必要があるため、sitemap.xmlを追加しました。developリポジトリ上でapp/sitemap.xmlを追加すると、gh-pagesに反映されると理解してますので、そこにおきました。マージをお願いします。
※ Google Search Consoleでのエラーは下記リンクのとおり。
https://www.google.com/webmasters/tools/sitemap-details?hl=ja&siteUrl=http%3A%2F%2Ffestival.code4chiba.org%2F&sitemapUrl=http%3A%2F%2Ffestival.code4chiba.org%2Fsitemap.xml&gwtPl=L3dlYm1hc3RlcnMvdG9vbHMvc2l0ZW1hcC1saXN0P2hsPWphJnNpdGVVcmw9aHR0cDovL2Zlc3RpdmFsLmNvZGU0Y2hpYmEub3JnLyNNQUlOX1RBQj0wJkNBUkRfVEFCPS0x#CARD_TAB=-1&ISSUE_FILTER=0
