### PR TITLE
祭りデータの期間が日付のみ場合と開始時刻のみ場合の対応

### DIFF
--- a/app/scripts/views/fes-detail.tag
+++ b/app/scripts/views/fes-detail.tag
@@ -12,7 +12,10 @@
           <li each={ period, i in fes.periods }>
             <span class="date">{moment(period.start).format('MM/DD')}</span>
             <span class={day-of-week:true,sat:6===period.start.getDay(),sun:0===period.start.getDay()}>{moment(period.start).format('dd')}</span>
-            <span class="clock">{moment(period.start).format('HH:mm')} - {moment(period.end).format('HH:mm')}</span>
+            <span class="clock">
+              <span if={moment(period.start).format('HH:mm') != '00:00'}>{moment(period.start).format('HH:mm')}</span>
+              <span if={moment(period.end).format('HH:mm') != '00:00'}> - {moment(period.end).format('HH:mm')}</span>
+            </span>
           </li>
         </ul>
 

--- a/app/scripts/views/fes-list.tag
+++ b/app/scripts/views/fes-list.tag
@@ -16,8 +16,8 @@
               {moment(fes.getStartDate()).format('MM/DD')}
               <span class="small">{moment(fes.getStartDate()).format('dd')}</span>
               -
-              {moment(fes.getEndDate()).format('MM/DD')}
-              <span class="small">{moment(fes.getEndDate()).format('dd')}</span>
+              {moment(fes.getUniquePeriods()[fes.getUniquePeriods().length - 1].start).format('MM/DD')}
+              <span class="small">{moment(fes.getUniquePeriods()[fes.getUniquePeriods().length - 1].start).format('dd')}</span>
             </span>
           </p>
           <p class="title">{fes.name}</p>


### PR DESCRIPTION
詳細画面の時刻表示の変更と、一覧画面の祭り期間が１日多く表示されてしまっていたので修正
