### PR TITLE
時刻が無いデータの場合、１日前のデータまで取得してしまう問題解消

### DIFF
--- a/app/scripts/models/event.js
+++ b/app/scripts/models/event.js
@@ -88,7 +88,7 @@
         if (param.fromDate) {
           var fromDate = getDateTime(param.fromDate);
           isInclude = _.some(fes.periods, function (period) {
-            return getDateTime(period.end) >= fromDate;
+            return getDateTime(period.start) >= fromDate;
           });
           if (!isInclude) {
             return false;


### PR DESCRIPTION
時刻がないデータのデータ構造は現状のままで検索が正しくされるように修正しました。

検索処理の中では日付までの値でしか比較していないので、endの日付を一切見ずに、startの日付だけで検索するように修正しました。
