### PR TITLE
endの時刻がnullでも動くようにする

### DIFF
--- a/app/scripts/models/event.js
+++ b/app/scripts/models/event.js
@@ -88,7 +88,7 @@
         if (param.fromDate) {
           var fromDate = getDateTime(param.fromDate);
           isInclude = _.some(fes.periods, function (period) {
-            return getDateTime(period.end) >= fromDate;
+            return getDateTime(period.start) >= fromDate;
           });
           if (!isInclude) {
             return false;

--- a/app/scripts/models/event.js
+++ b/app/scripts/models/event.js
@@ -37,7 +37,12 @@
      * @returns {Date} 最終日の終了日時
      */
     getEndDate: function () {
-      return this.periods[this.periods.length - 1].end;
+      var endDatetime = this.periods[this.periods.length - 1].end;
+      if (endDatetime) {
+        return endDatetime;
+      } else {
+        return this.periods[this.periods.length - 1].start;
+      }
     },
 
     /**

--- a/app/scripts/stores/eventStore.js
+++ b/app/scripts/stores/eventStore.js
@@ -18,7 +18,7 @@
         // 日付をDate型に変換
         data.periods = _.map(data.periods, function (period) {
           period.start = new Date(period.start);
-          period.end = new Date(period.end);
+          period.end = (period.end ?  new Date(period.end) : null);
           return period;
         });
         this.dataStore[data.id] = new cfc.Event(data);

--- a/app/scripts/views/fes-detail.tag
+++ b/app/scripts/views/fes-detail.tag
@@ -13,8 +13,8 @@
             <span class="date">{moment(period.start).format('MM/DD')}</span>
             <span class={day-of-week:true,sat:6===period.start.getDay(),sun:0===period.start.getDay()}>{moment(period.start).format('dd')}</span>
             <span class="clock">
-              <span if={moment(period.start).format('HH:mm') != '00:00'}>{moment(period.start).format('HH:mm')}</span>
-              <span if={moment(period.end).format('HH:mm') != '00:00'}> - {moment(period.end).format('HH:mm')}</span>
+              <span>{moment(period.start).format('HH:mm')}</span>
+              <span if={period.end != null}> - {moment(period.end).format('HH:mm')}</span>
             </span>
           </li>
         </ul>


### PR DESCRIPTION
endの時刻がnullでも動くようにしました。

これで解決できる問題は詳細画面で「0時0分だったら」という分岐が「nullだったら」という分岐になって意図がちょっとだけわかりやすくなります。

想定データ構造
・開始時刻のみ
　－＞startに開始時刻設定　／　endはnull
・日付のみ
　－＞startに日付+0時0分　／　endはnull

これを取り込むにはjsonデータの生成処理も合わせて修正する必要があります。
リファクタブランチなので取り込まなくてもＯＫです。
