### PR TITLE
TypeSquare API を無効化

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -71,7 +71,6 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.2/underscore-min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.6/fastclick.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/leaflet.markercluster.js"></script>
-    <script src="//typesquare.com/accessor/apiscript/typesquare.js?Gd-7b3LiHK4%3D"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.1/js/lightbox.min.js"></script>
     <!-- build:js(app) scripts/vendor.js -->
     <script src="scripts/vendor/leaflet.label.js"></script>

--- a/app/scripts/views/about.tag
+++ b/app/scripts/views/about.tag
@@ -1,5 +1,5 @@
 <about>
-  <article class="content matsuri-style">
+  <article class="content">
     <section id="about-introduction">
       <img src="/images/facebook.jpg">
       <p>本サービスは、千葉市で長い間親しまれているお祭りについて、お知らせする無料サービスです。</p>

--- a/app/scripts/views/app-footer.tag
+++ b/app/scripts/views/app-footer.tag
@@ -1,6 +1,6 @@
 <app-footer>
   <footer>
-    <ul class="clearfix matsuri-style">
+    <ul class="clearfix">
       <li>
         <a href="javascript:void(0)" onclick="{showAbout}">このサービスについて</a>
       </li>

--- a/app/scripts/views/credit.tag
+++ b/app/scripts/views/credit.tag
@@ -1,8 +1,8 @@
 <credit>
   <article class="content">
     <section id="credit-list">
-      <h1 class="matsuri-style">クレジット</h1>
-      <h2 class="matsuri-style">企画</h2>
+      <h1>クレジット</h1>
+      <h2>企画</h2>
       <ul class="clearfix">
         <li>
           <member uuid="6735387e-450f-44ee-9ced-91ae797c0c97"></member>
@@ -21,7 +21,7 @@
         <li>YAMAMOTO Munehiro</li>
         <li>SHIMIZU Yasuo</li>
       </ul>
-      <h2 class="matsuri-style">エンジニア</h2>
+      <h2>エンジニア</h2>
       <ul class="clearfix">
         <li>
           <member uuid="ddb396bd-dc7b-4d20-ae7a-df2e2470c377"></member>
@@ -36,12 +36,12 @@
           <member uuid="8c633cf3-fb3c-4710-86cb-6bce874d98c0"></member>
         </li>
       </ul>
-      <h2 class="matsuri-style">デザイナー</h2>
+      <h2>デザイナー</h2>
       <ul class="clearfix">
         <li>
           <member uuid="aebfcc03-ead7-445c-9e41-f78ae07fd2ce"></member>
       </ul>
-      <h2 class="matsuri-style">アドバイザー</h2>
+      <h2>アドバイザー</h2>
       <ul class="clearfix">
         <li>
           <member uuid="b9010dbd-ef0b-484a-a64b-6c7ee0baf73f"></member>
@@ -56,7 +56,7 @@
       </ul>
     </section>
     <section id="credit-navi">
-      <p class="matsuri-style">
+      <p>
         <a href="javascript:void(0)" onclick="{doHome}">
           トップへ戻る
         </a>

--- a/app/scripts/views/fes-detail.tag
+++ b/app/scripts/views/fes-detail.tag
@@ -7,11 +7,11 @@
     </div>
     <article class="content">
       <div class="info-area">
-        <h4 class="detail-title matsuri-style">{fes.name}</h4>
+        <h4 class="detail-title">{fes.name}</h4>
         <ul class="day-time">
           <li each={ period, i in fes.periods }>
             <span class="date">{moment(period.start).format('MM/DD')}</span>
-            <span class={matsuri-style:true,day-of-week:true,sat:6===period.start.getDay(),sun:0===period.start.getDay()}>{moment(period.start).format('dd')}</span>
+            <span class={day-of-week:true,sat:6===period.start.getDay(),sun:0===period.start.getDay()}>{moment(period.start).format('dd')}</span>
             <span class="clock">
               <span if={moment(period.start).format('HH:mm') != '00:00'}>{moment(period.start).format('HH:mm')}</span>
               <span if={moment(period.end).format('HH:mm') != '00:00'}> - {moment(period.end).format('HH:mm')}</span>
@@ -57,7 +57,7 @@
           <img if={fes.features.fireworks} src="images/detail/Detail_icon06.svg" />
         </div>
 
-        <dl class="fes-infos matsuri-style">
+        <dl class="fes-infos">
         <dt>会　場</dt>
         <dd>{fes.location.name}</dd>
         <dt>住　所</dt>
@@ -87,7 +87,7 @@
         </div>
       </div>
       <div id="map-detail"></div>
-      <div class="title matsuri-style">周辺のお祭り</div>
+      <div class="title">周辺のお祭り</div>
       <fes-list feslist={aroundFes}></fes-list>
     </article>
   </div>
@@ -151,8 +151,6 @@
         self.fetchWeather(fes);
         // 祭りに関する画像を取得
         self.fetchImages(fes);
-
-        Ts.reload();
       });
     });
 

--- a/app/scripts/views/fes-list.tag
+++ b/app/scripts/views/fes-list.tag
@@ -8,19 +8,19 @@
           <p class="day" if={fes.getUniquePeriods().length <= 2}>
             <span class="bgcolor" each={ period in fes.getUniquePeriods() } >
               {moment(period.start).format('MM/DD')}
-              <span class="small matsuri-style">{moment(period.start).format('dd')}</span>
+              <span class="small">{moment(period.start).format('dd')}</span>
             </span>
           </p>
           <p class="day" if={fes.getUniquePeriods().length > 2}>
             <span class="bgcolor" >
               {moment(fes.getStartDate()).format('MM/DD')}
-              <span class="small matsuri-style">{moment(fes.getStartDate()).format('dd')}</span>
+              <span class="small">{moment(fes.getStartDate()).format('dd')}</span>
               -
               {moment(fes.getUniquePeriods()[fes.getUniquePeriods().length - 1].start).format('MM/DD')}
-              <span class="small matsuri-style">{moment(fes.getUniquePeriods()[fes.getUniquePeriods().length - 1].start).format('dd')}</span>
+              <span class="small">{moment(fes.getUniquePeriods()[fes.getUniquePeriods().length - 1].start).format('dd')}</span>
             </span>
           </p>
-          <p class="title matsuri-style">{fes.name}</p>
+          <p class="title">{fes.name}</p>
           </dt>
           <dd>
             <a href="javascript:void(0)">
@@ -37,10 +37,6 @@
     onSelectFes(e){
       riot.route("detail/" + e.item.fes.id);
     }
-
-    this.on('updated', function() {
-      Ts.reload();
-    });
 
     /**
      * 画像h表示に失敗した場合はデフォルト画像を表示

--- a/app/scripts/views/home.tag
+++ b/app/scripts/views/home.tag
@@ -10,7 +10,7 @@
       <div class="homesearch-list">
         <a href="javascript:void(0)" onclick={doClickCitySearchPanel}>
           <img src="images/home/icon01.svg">
-          <p class="matsuri-style">地域から探す</p>
+          <p>地域から探す</p>
         </a>
       </div>
 
@@ -18,7 +18,7 @@
         <a href="javascript:void(0)" onclick={doSearchToday}>
           <img src="images/home/icon02.svg">
 
-          <p class="matsuri-style">本日開催の祭り</p>
+          <p>本日開催の祭り</p>
         </a>
       </div>
 
@@ -26,12 +26,12 @@
         <a href="javascript:void(0)" onclick={doSearchThisWeekEnd}>
           <img src="images/home/icon03.svg">
 
-          <p class="matsuri-style">土日開催の祭り</p>
+          <p>土日開催の祭り</p>
         </a>
       </div>
     </section>
     <section id="city-search" style="display:none">
-      <ul class="homesearch matsuri-style">
+      <ul class="homesearch">
         <li class="homesearch-list" each={ city in cities }>
           <a href="javascript:void(0)" onclick={parent.doSearchCity}>
             <p>{city.city}</p>
@@ -42,7 +42,7 @@
     </section>
     <section class="week">
       <dl class="week-day">
-        <dt class="matsuri-style">今週開催の祭り</dt>
+        <dt>今週開催の祭り</dt>
         <dd>{moment(startDateOfWeek).format('M/D')} - {moment(endDateOfWeek).format('M/D')}</dd>
       </dl>
 

--- a/app/scripts/views/search-calendar.tag
+++ b/app/scripts/views/search-calendar.tag
@@ -75,10 +75,6 @@
       background-color:#FFF5F5;
     }
 
-    .fc-event .fc-toolbar .fc-left, .fc-event .fc-day-header, .fc-event .fc-content {
-      font-family: "勘亭流",Kanteiryu,"ヒラギノ角ゴ Pro W3","Hiragino Kaku Gothic Pro","メイリオ",Meiryo,"ＭＳ Ｐゴシック",arial,helvetica,clean,sans-serif;
-    }
-
     .fc-event .fc-toolbar, .fc-left {
       font-size: 15px;
     }

--- a/app/scripts/views/search.tag
+++ b/app/scripts/views/search.tag
@@ -9,7 +9,7 @@
   <article class="content">
 
     <form onsubmit={onSubmitSearch}>
-      <h4 class="matsuri-style">期間を選択してください。</h4>
+      <h4>期間を選択してください。</h4>
       <div class="form-group row">
         <div class="col-xs-6">
           <input type="text" class="form-control" id="fromDate" >
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <h4 class="matsuri-style">地域を選択してください。</h4>
+      <h4>地域を選択してください。</h4>
       <div class="form-group">
         <select class="form-control" id="cities"></select>
       </div>
@@ -34,19 +34,19 @@
         <li class={'tab-item': true, active: path==='list'}>
           <a href="#search/list?{queryString}">
             <img src="images/search/icon01.svg">
-            <p class="matsuri-style">一覧</p>
+            <p>一覧</p>
           </a>
         </li>
         <li class={'tab-item': true, active: path==='map'}>
           <a href="#search/map?{queryString}">
             <img src="images/search/icon02.svg">
-            <p class="matsuri-style">地図</p>
+            <p>地図</p>
           </a>
         </li>
         <li class={'tab-item': true, active: path==='cal'}>
           <a href="#search/cal?{queryString}">
             <img src="images/search/icon03.svg">
-            <p class="matsuri-style">カレンダー</p>
+            <p>カレンダー</p>
           </a>
         </li>
       </ul>

--- a/app/styles/base.scss
+++ b/app/styles/base.scss
@@ -115,10 +115,3 @@ c l e a r f i x
   display: table;
   clear: both;
 }
-
-/* ==================================
-m a t s u r i - s t y l e
-================================== */
-.matsuri-style {
-  font-family: "勘亭流",Kanteiryu,"ヒラギノ角ゴ Pro W3","Hiragino Kaku Gothic Pro","メイリオ",Meiryo,"ＭＳ Ｐゴシック",arial,helvetica,clean,sans-serif;
-}


### PR DESCRIPTION
2016/1/31 でライセンスが失効するので、その前に無効化します。

Fixed #161
