### PR TITLE
Docker開発環境で35729ポートを公開するように設定

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ RUN apk add --no-cache ${ADDITIONAL_PKGS} && \
   npm install --unsafe-perm && \
   grunt build
 
-EXPOSE 9000
+EXPOSE 9000 35729
 ENV NODE_ENV="development"
 
 CMD ["grunt", "serve:express"]


### PR DESCRIPTION
livereload-jsで使うwebsocketの35729ポートをEXPOSEした
fix #299 