### PR TITLE
検索画面のタイトルがずれている問題の修正

### DIFF
--- a/app/scripts/views/announcement.tag
+++ b/app/scripts/views/announcement.tag
@@ -23,7 +23,7 @@
     });
   </script>
 
-  <style scorped>
+  <style scoped>
   .main .main-img h2 {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
Scoped CSS になっていなかったので修正

connected to #325 